### PR TITLE
solved.ac API를 활용한 태그 데이터 수집

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// gson
+	implementation 'com.google.code.gson:gson:2.10.1'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/study/study_log/common/entity/BaseEntity.java
+++ b/src/main/java/com/study/study_log/common/entity/BaseEntity.java
@@ -16,10 +16,10 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(name = "create_at", updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "update_at")
-    private LocalDateTime updateAt;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/study/study_log/common/util/SolvedAcApi.java
+++ b/src/main/java/com/study/study_log/common/util/SolvedAcApi.java
@@ -8,6 +8,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
+/**
+ * Solved.ac API 요청 공통 유틸 클래스
+ * 다양한 응답 DTO(태그, 문제 등)를 재사용하기 위해 제네릭 타입으로 반환한다.
+ * ex) SolvedAcTagRes, SolvedAcProblemRes
+ */
 public class SolvedAcApi {
     private static final HttpClient CLIENT = HttpClient.newHttpClient();
     private static final Gson gson = new Gson();

--- a/src/main/java/com/study/study_log/common/util/SolvedAcApi.java
+++ b/src/main/java/com/study/study_log/common/util/SolvedAcApi.java
@@ -1,0 +1,27 @@
+package com.study.study_log.common.util;
+
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class SolvedAcApi {
+    private static final HttpClient CLIENT = HttpClient.newHttpClient();
+    private static final Gson gson = new Gson();
+
+    public static <T> T requestSolvedAcApi(String uri, Class<T> clazz) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(uri))
+                .header("x-solvedac-language", "ko")
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+
+        HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
+        return gson.fromJson(response.body(), clazz);
+    }
+}

--- a/src/main/java/com/study/study_log/problem/controller/ProblemController.java
+++ b/src/main/java/com/study/study_log/problem/controller/ProblemController.java
@@ -1,0 +1,25 @@
+package com.study.study_log.problem.controller;
+
+import com.study.study_log.common.util.SolvedAcApi;
+import com.study.study_log.problem.dto.SolvedacTagRes;
+import com.study.study_log.problem.service.ProblemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/problems")
+public class ProblemController {
+    private final ProblemService problemService;
+
+    // solved.ac 태그 데이터를 가져와 DB에 저장하는 API
+    @GetMapping("/tags")
+    public void getProblemTag() throws IOException, InterruptedException {
+        SolvedacTagRes response = SolvedAcApi.requestSolvedAcApi("https://solved.ac/api/v3/tag/list", SolvedacTagRes.class);
+        problemService.createSolvedAcTag(response);
+    }
+}

--- a/src/main/java/com/study/study_log/problem/dto/SolvedacTagRes.java
+++ b/src/main/java/com/study/study_log/problem/dto/SolvedacTagRes.java
@@ -4,6 +4,10 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * Solved.ac 태그 API 응답 DTO
+ * TagItem, DisplayName는 해당 응답에서만 사용되므로 별도 파일로 분리하지 않고 inner 클래스로 구성
+ */
 @Getter
 public class SolvedacTagRes {
     private List<TagItem> items;

--- a/src/main/java/com/study/study_log/problem/dto/SolvedacTagRes.java
+++ b/src/main/java/com/study/study_log/problem/dto/SolvedacTagRes.java
@@ -1,0 +1,21 @@
+package com.study.study_log.problem.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SolvedacTagRes {
+    private List<TagItem> items;
+
+    public static class TagItem {
+        private String key;
+        private int bojTagId;
+        private List<DisplayName> displayNames;
+    }
+
+    public static class DisplayName {
+        private String language;
+        private String name;
+    }
+}

--- a/src/main/java/com/study/study_log/problem/dto/SolvedacTagRes.java
+++ b/src/main/java/com/study/study_log/problem/dto/SolvedacTagRes.java
@@ -12,12 +12,13 @@ import java.util.List;
 public class SolvedacTagRes {
     private List<TagItem> items;
 
+    @Getter
     public static class TagItem {
         private String key;
-        private int bojTagId;
+        private Long bojTagId;
         private List<DisplayName> displayNames;
     }
-
+    @Getter
     public static class DisplayName {
         private String language;
         private String name;

--- a/src/main/java/com/study/study_log/problem/entity/SolvedAcTag.java
+++ b/src/main/java/com/study/study_log/problem/entity/SolvedAcTag.java
@@ -1,0 +1,39 @@
+package com.study.study_log.problem.entity;
+
+import com.study.study_log.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SolvedAcTag extends BaseEntity {
+    @Id
+    @Column(name = "id")
+    @Comment("태그 내부 pk")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "tag_key", nullable = false, unique = true)
+    @Comment("solved.ac에서 쓰는 태그 ID")
+    private String key;
+
+    @Column(name = "boj_tag_id", nullable = false, unique = true)
+    @Comment("백준 온라인 저지에서 쓰는 태그 ID")
+    private Long bojTagId;
+
+    @Column(name = "name", nullable = false)
+    @Comment("태그 이름")
+    private String name;
+
+    @Builder
+    private SolvedAcTag(String key, Long bojTagId, String name) {
+        this.key = key;
+        this.bojTagId = bojTagId;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/study/study_log/problem/repository/ProblemTagRepository.java
+++ b/src/main/java/com/study/study_log/problem/repository/ProblemTagRepository.java
@@ -1,0 +1,7 @@
+package com.study.study_log.problem.repository;
+
+import com.study.study_log.problem.entity.SolvedAcTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemTagRepository extends JpaRepository<SolvedAcTag, Long> {
+}

--- a/src/main/java/com/study/study_log/problem/service/ProblemService.java
+++ b/src/main/java/com/study/study_log/problem/service/ProblemService.java
@@ -1,0 +1,48 @@
+package com.study.study_log.problem.service;
+
+import com.study.study_log.problem.dto.SolvedacTagRes;
+import com.study.study_log.problem.entity.SolvedAcTag;
+import com.study.study_log.problem.repository.ProblemTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemService {
+    private final ProblemTagRepository problemTagRepository;
+    private static final String DEFAULT_LANGUAGE = "ko";
+
+    // solved.ac 태그 API 응답 데이터를 db에 저장
+    public void createSolvedAcTag(SolvedacTagRes response) {
+        List<SolvedAcTag> list = new ArrayList<>();
+
+        // 태그 목록 순회
+        for(SolvedacTagRes.TagItem item : response.getItems()) {
+            // 한국어 이름 추출(DEFAULT_LANGUAGE = "ko")
+            String koName = extractNameByLanguage(item, DEFAULT_LANGUAGE);
+
+            SolvedAcTag solvedAcTag = SolvedAcTag.builder()
+                    .key(item.getKey())
+                    .bojTagId(item.getBojTagId())
+                    .name(koName)
+                    .build();
+
+            list.add(solvedAcTag);
+        }
+
+        problemTagRepository.saveAll(list);
+    }
+
+    // 특정 언어에 해당하는 태그 이름 찾는 메서드
+    private String extractNameByLanguage(SolvedacTagRes.TagItem item, String defaultLanguage) {
+        for(SolvedacTagRes.DisplayName displayName : item.getDisplayNames()) {
+            if(defaultLanguage.equals(displayName.getLanguage())) {
+                return displayName.getName();
+            }
+        }
+        return "unKnown"; // todo: 어떻게 처리 하는게 좋을지...??
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,8 @@ spring:
     show-sql: true
     defer-datasource-initialization: true       # data.sql 초기화 필요시 사용
     hibernate:
-      ddl-auto: create                          # 엔티티 기반 테이블 자동 생성/업데이트
+      ddl-auto: none                          # 엔티티 기반 테이블 자동 생성/업데이트
   sql:
     init:
-      mode: always                              # 어플리케이션 실행 시 항상 실행되게 함
+      mode: never                              # 어플리케이션 실행 시 항상 실행되게 함
       encoding: UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:                                   # H2는 기본 비밀번호 없음(비워도 됌)
+    url: jdbc:mysql://localhost:3306/study_log?allowPublicKeyRetrieval=true&useSSL=false
+    username: kjs
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
   h2:
     console:
       enabled: true                             # 웹 콘솔 사용 가능 http://localhost:8080/h2-console

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,29 @@
--- 상위 메뉴 1
-INSERT INTO solve (title, level, solved_count, tag, description)
-VALUES ('타겟넘버', 2, 1, 'dfs', '어렵다');
-INSERT INTO solve (title, level, solved_count, tag, description)
-VALUES ('최단 맵 거리', 3, 3, 'bfs', '쉽다');
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('스티커', 10, 2, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('구간 합 구하기 5', 10, 1, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('동전 1', 12, 2, 'dp', '어려움', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('가장 큰 증가하는 부분 수열', 8, 1, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('가장 긴 감소하는 부분 수열', 8, 2, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('오르막 수', 10, 1, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('카드 구매하기', 10, 2, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('제곱수의 합', 8, 1, 'dp', '보통', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('동전 2', 11, 2, 'dp', '어려움', now(), now());
+
+INSERT INTO solve (title, level, solved_count, tag, description, created_at, updated_at)
+VALUES ('LCS', 12, 1, 'dp', '어려움', now(), now());


### PR DESCRIPTION
- DB를 H2에서 MySQL로 전환
- Solved.ac API 응답값에 맞는 태그 dto 작성
- solvedacTag erdCloud작성 및 엔티티 추가
- solved.ac의 태그 API를 호출하여 전체 데이터를 수집하고 DB에 저장

closes #5 