### PR TITLE
feat : solved.ac API를 활용한 문제 데이터 수집

### DIFF
--- a/src/main/java/com/study/study_log/problem/controller/ProblemController.java
+++ b/src/main/java/com/study/study_log/problem/controller/ProblemController.java
@@ -1,6 +1,7 @@
 package com.study.study_log.problem.controller;
 
 import com.study.study_log.common.util.SolvedAcApi;
+import com.study.study_log.problem.dto.SolvedAcProblemRes;
 import com.study.study_log.problem.dto.SolvedacTagRes;
 import com.study.study_log.problem.service.ProblemService;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,12 @@ public class ProblemController {
     public void getProblemTag() throws IOException, InterruptedException {
         SolvedacTagRes response = SolvedAcApi.requestSolvedAcApi("https://solved.ac/api/v3/tag/list", SolvedacTagRes.class);
         problemService.createSolvedAcTag(response);
+    }
+
+    // solved.ac  문제 데이터를 가져와 DB에 저장하는 API
+    @GetMapping()
+    public void getProblem() throws IOException, InterruptedException {
+        SolvedAcProblemRes response = SolvedAcApi.requestSolvedAcApi("https://solved.ac/api/v3/search/problem?query=&page=1", SolvedAcProblemRes.class);
+        problemService.createSolvedAcProblem(response);
     }
 }

--- a/src/main/java/com/study/study_log/problem/controller/ProblemController.java
+++ b/src/main/java/com/study/study_log/problem/controller/ProblemController.java
@@ -27,7 +27,11 @@ public class ProblemController {
     // solved.ac  문제 데이터를 가져와 DB에 저장하는 API
     @GetMapping()
     public void getProblem() throws IOException, InterruptedException {
-        SolvedAcProblemRes response = SolvedAcApi.requestSolvedAcApi("https://solved.ac/api/v3/search/problem?query=&page=1", SolvedAcProblemRes.class);
-        problemService.createSolvedAcProblem(response);
+        int totalPages = 677;
+
+        for(int i=1; i<=totalPages; i++) {
+            SolvedAcProblemRes response = SolvedAcApi.requestSolvedAcApi("https://solved.ac/api/v3/search/problem?query=&page=" + i, SolvedAcProblemRes.class);
+            problemService.createSolvedAcProblem(response);
+        }
     }
 }

--- a/src/main/java/com/study/study_log/problem/dto/SolvedAcProblemRes.java
+++ b/src/main/java/com/study/study_log/problem/dto/SolvedAcProblemRes.java
@@ -1,0 +1,24 @@
+package com.study.study_log.problem.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SolvedAcProblemRes {
+    private List<ProblemItem> items;
+
+    @Getter
+    public static class ProblemItem {
+        private Long problemId;
+        private int acceptedUserCount;
+        private String titleKo;
+        private int level;
+        private List<Tag> tags;
+    }
+
+    @Getter
+    public static class Tag {
+        private int bojTagId;
+    }
+}

--- a/src/main/java/com/study/study_log/problem/dto/SolvedAcProblemRes.java
+++ b/src/main/java/com/study/study_log/problem/dto/SolvedAcProblemRes.java
@@ -4,6 +4,10 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * Solved.ac 문제 API 응답 DTO
+ * ProblemItem, Tag는 해당 응답에서만 사용되므로 별도 파일로 분리하지 않고 inner 클래스로 구성
+ */
 @Getter
 public class SolvedAcProblemRes {
     private List<ProblemItem> items;

--- a/src/main/java/com/study/study_log/problem/entity/SolvedAcProblem.java
+++ b/src/main/java/com/study/study_log/problem/entity/SolvedAcProblem.java
@@ -7,6 +7,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Solved.ac 문제 정보를 저장하는 엔티티
+ * 하나의 문제는 여러 개의 태그를 가질 수 있으며
+ * SolvedAcProblemTag를 통해 태그와 다대다 관계를 관리
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -32,11 +40,24 @@ public class SolvedAcProblem {
     @Comment("문제 난이도입니다")
     private int level;
 
+    /**
+     * 문제 - 태그 매핑 테이블
+     * SolvedAcProblemTag를 통해 태그와 다대다 관계를 중간 엔티티로 관리
+     */
+    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SolvedAcProblemTag> problemTags = new ArrayList<>();
+
     @Builder
-    private SolvedAcProblem(Long problemId, int acceptedUserCount, String koTitle, int level) {
+    private SolvedAcProblem(Long problemId, int acceptedUserCount, String koTitle, int level, List<SolvedAcProblemTag> problemTags) {
         this.problemId = problemId;
         this.acceptedUserCount = acceptedUserCount;
         this.koTitle = koTitle;
         this.level = level;
     }
+
+    public void addTag(SolvedAcTag tag) {
+        SolvedAcProblemTag problemTag = new SolvedAcProblemTag(tag, this);
+        this.problemTags.add(problemTag);
+    }
+
 }

--- a/src/main/java/com/study/study_log/problem/entity/SolvedAcProblem.java
+++ b/src/main/java/com/study/study_log/problem/entity/SolvedAcProblem.java
@@ -16,7 +16,7 @@ public class SolvedAcProblem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "problem_id", nullable = false)
+    @Column(name = "problem_id", nullable = false, unique = true)
     @Comment("백준 문제 번호로, 문제마다 고유합니다.")
     private Long problemId;
 

--- a/src/main/java/com/study/study_log/problem/entity/SolvedAcProblem.java
+++ b/src/main/java/com/study/study_log/problem/entity/SolvedAcProblem.java
@@ -1,0 +1,42 @@
+package com.study.study_log.problem.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SolvedAcProblem {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "problem_id", nullable = false)
+    @Comment("백준 문제 번호로, 문제마다 고유합니다.")
+    private Long problemId;
+
+    @Column(name = "accepted_user_count")
+    @Comment("맞은 사람 수입니다.")
+    private int acceptedUserCount;
+
+    @Column(name = "ko_title", nullable = false)
+    @Comment("한국어 문제 제목입니다.")
+    private String koTitle;
+
+    @Column(name = "level", nullable = false)
+    @Comment("문제 난이도입니다")
+    private int level;
+
+    @Builder
+    private SolvedAcProblem(Long problemId, int acceptedUserCount, String koTitle, int level) {
+        this.problemId = problemId;
+        this.acceptedUserCount = acceptedUserCount;
+        this.koTitle = koTitle;
+        this.level = level;
+    }
+}

--- a/src/main/java/com/study/study_log/problem/entity/SolvedAcProblemTag.java
+++ b/src/main/java/com/study/study_log/problem/entity/SolvedAcProblemTag.java
@@ -1,0 +1,34 @@
+package com.study.study_log.problem.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 문제와 태그의 다대다 관계를 풀기 위한 중간 엔티티
+ * 하나의 문제는 여러 태그를 가질 수 있고
+ * 하나의 태그도 여러 문제에 사용될 수 있음
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SolvedAcProblemTag {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "boj_tag_id")
+    private SolvedAcTag tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private SolvedAcProblem problem;
+
+    public SolvedAcProblemTag(SolvedAcTag tag, SolvedAcProblem problem) {
+        this.tag = tag;
+        this.problem = problem;
+    }
+}

--- a/src/main/java/com/study/study_log/problem/entity/SolvedAcTag.java
+++ b/src/main/java/com/study/study_log/problem/entity/SolvedAcTag.java
@@ -8,6 +8,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Solved.ac 및 백준에서 사용하는 태그 정보를 저장하는 엔티티
+ * 하나의 태그는 여러 문제에서 사용될 수 있음
+ */
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +36,13 @@ public class SolvedAcTag extends BaseEntity {
     @Column(name = "name", nullable = false)
     @Comment("태그 이름")
     private String name;
+
+    /**
+     * 태그 - 문제 매핑 관계
+     * 중간 엔티티(SolvedAcProblemTag)를 통해 문제와 연결
+     */
+    @OneToMany(mappedBy = "tag")
+    private List<SolvedAcProblemTag> problemTags = new ArrayList<>();
 
     @Builder
     private SolvedAcTag(String key, Long bojTagId, String name) {

--- a/src/main/java/com/study/study_log/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/study/study_log/problem/repository/ProblemRepository.java
@@ -1,0 +1,7 @@
+package com.study.study_log.problem.repository;
+
+import com.study.study_log.problem.entity.SolvedAcProblem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemRepository extends JpaRepository<SolvedAcProblem, Long> {
+}

--- a/src/main/java/com/study/study_log/problem/repository/ProblemTagRepository.java
+++ b/src/main/java/com/study/study_log/problem/repository/ProblemTagRepository.java
@@ -4,4 +4,5 @@ import com.study.study_log.problem.entity.SolvedAcTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemTagRepository extends JpaRepository<SolvedAcTag, Long> {
+    SolvedAcTag findByBojTagId(int bojTagId);
 }

--- a/src/main/java/com/study/study_log/problem/service/ProblemService.java
+++ b/src/main/java/com/study/study_log/problem/service/ProblemService.java
@@ -1,7 +1,10 @@
 package com.study.study_log.problem.service;
 
+import com.study.study_log.problem.dto.SolvedAcProblemRes;
 import com.study.study_log.problem.dto.SolvedacTagRes;
+import com.study.study_log.problem.entity.SolvedAcProblem;
 import com.study.study_log.problem.entity.SolvedAcTag;
+import com.study.study_log.problem.repository.ProblemRepository;
 import com.study.study_log.problem.repository.ProblemTagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProblemService {
     private final ProblemTagRepository problemTagRepository;
+    private final ProblemRepository problemRepository;
     private static final String DEFAULT_LANGUAGE = "ko";
 
     // solved.ac 태그 API 응답 데이터를 db에 저장
@@ -34,6 +38,21 @@ public class ProblemService {
         }
 
         problemTagRepository.saveAll(list);
+    }
+
+    public void createSolvedAcProblem(SolvedAcProblemRes response) {
+        List<SolvedAcProblem> list = new ArrayList<>();
+        for(SolvedAcProblemRes.ProblemItem item : response.getItems()) {
+            SolvedAcProblem solvedAcProblem = SolvedAcProblem.builder()
+                    .problemId(item.getProblemId())
+                    .acceptedUserCount(item.getAcceptedUserCount())
+                    .koTitle(item.getTitleKo())
+                    .level(item.getLevel())
+                    .build();
+
+            list.add(solvedAcProblem);
+        }
+        problemRepository.saveAll(list);
     }
 
     // 특정 언어에 해당하는 태그 이름 찾는 메서드

--- a/src/main/java/com/study/study_log/problem/service/ProblemService.java
+++ b/src/main/java/com/study/study_log/problem/service/ProblemService.java
@@ -40,8 +40,11 @@ public class ProblemService {
         problemTagRepository.saveAll(list);
     }
 
+    // solved.ac 문제 API 응답 데이터를 db에 저장
     public void createSolvedAcProblem(SolvedAcProblemRes response) {
-        List<SolvedAcProblem> list = new ArrayList<>();
+        List<SolvedAcProblem> problems = new ArrayList<>();
+
+        // 문제 목록 순회
         for(SolvedAcProblemRes.ProblemItem item : response.getItems()) {
             SolvedAcProblem solvedAcProblem = SolvedAcProblem.builder()
                     .problemId(item.getProblemId())
@@ -50,9 +53,18 @@ public class ProblemService {
                     .level(item.getLevel())
                     .build();
 
-            list.add(solvedAcProblem);
+            // 해당 문제의 태그 목록 순회
+            for(SolvedAcProblemRes.Tag tagItem : item.getTags()) {
+                // DB에서 실제로 태그가 존재하는지 조회 (bojTagId 기준)
+                SolvedAcTag tag = problemTagRepository.findByBojTagId(tagItem.getBojTagId());
+
+                // 문제 엔티티에 태그 연관관계 추가
+                solvedAcProblem.addTag(tag);
+            }
+
+            problems.add(solvedAcProblem);
         }
-        problemRepository.saveAll(list);
+        problemRepository.saveAll(problems);
     }
 
     // 특정 언어에 해당하는 태그 이름 찾는 메서드

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     show-sql: true
     defer-datasource-initialization: true       # data.sql 초기화 필요시 사용
     hibernate:
-      ddl-auto: none                          # 엔티티 기반 테이블 자동 생성/업데이트
+      ddl-auto: update                          # 엔티티 기반 테이블 자동 생성/업데이트
   sql:
     init:
       mode: never                              # 어플리케이션 실행 시 항상 실행되게 함


### PR DESCRIPTION
- solved.ac API 응답값에 맞는 문제 dto 작성
- solvedAcProblem erdCloud 작성 및 엔티티 추가
- solved.ac의 문제 API를 호출하여 전체 데이터를 수집하고 DB에 저장
- SolvedAcProblemTag(problem ↔ tag) 매핑 erd 작성 및 엔티티 추가 및 SolvedAcTag, SolvedAcProblem 연관관계 설정
- SolvedAcProblemTag에 문제 api 호출시 Tags 객체 데이터 수집하고 DB에 저장

closes #7 